### PR TITLE
add debug level

### DIFF
--- a/params/env.go
+++ b/params/env.go
@@ -481,6 +481,8 @@ func (e *envParams) LogLevel(key string, optionSetters ...OptionSetter) (level l
 		return logging.WarnLevel, nil
 	case "error":
 		return logging.ErrorLevel, nil
+	case "debug":
+		return logging.DebugLevel, nil
 	default:
 		return level, fmt.Errorf("environment variable %s: %w: %q", key, ErrUnknownLogLevel, s)
 	}


### PR DESCRIPTION
I think debug logs in ddns-updater would help maintain the project. It is not possible to add debug logs at the moment because the log lib (zap) is abstracted by qdm12/golibs which does not implement debug

```sh
environment variable LOG_LEVEL: unknown log level: "debug"
```


You might want to also add an entry for debug on https://github.com/qdm12/golibs/blob/master/params/env_test.go
However:
1. I expect zap to already be tested
2. 100% coverage on a function with a simple constant = other constant seem overkill